### PR TITLE
Updating YAML files to remove unnecessary line in permissions

### DIFF
--- a/.github/workflows/changelog-to-fastlane.yml
+++ b/.github/workflows/changelog-to-fastlane.yml
@@ -6,20 +6,11 @@ on:
       - main
     paths:
       - 'CHANGELOG.md'
+
 permissions:
-  actions: none
-  checks: none
   contents: write
-  deployments: none
-  discussions: none
-  id-token: none
-  issues: none
-  packages: none
-  pages: none
   pull-requests: write
-  repository-projects: none
-  security-events: none
-  statuses: none
+
 jobs:
   convert_changelog_to_fastlane:
     runs-on: ubuntu-latest

--- a/.github/workflows/changelog-to-fastlane.yml
+++ b/.github/workflows/changelog-to-fastlane.yml
@@ -1,4 +1,5 @@
 name: Convert CHANGELOG to Fastlane
+
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/contributors-to-file.yml
+++ b/.github/workflows/contributors-to-file.yml
@@ -3,20 +3,11 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '3 4 * * 0'
+
 permissions:
-  actions: none
-  checks: none
   contents: write
-  deployments: none
-  discussions: none
-  id-token: none
-  issues: none
-  packages: none
-  pages: none
   pull-requests: write
-  repository-projects: none
-  security-events: none
-  statuses: none
+
 jobs:
   contributors_to_file:
     runs-on: ubuntu-latest

--- a/.github/workflows/contributors-to-file.yml
+++ b/.github/workflows/contributors-to-file.yml
@@ -1,4 +1,5 @@
 name: Write contributors to file
+
 on:
   workflow_dispatch:
   schedule:

--- a/.github/workflows/generate-feature-graphic.yml
+++ b/.github/workflows/generate-feature-graphic.yml
@@ -1,4 +1,5 @@
 name: Generate feature graphic
+
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/generate-feature-graphic.yml
+++ b/.github/workflows/generate-feature-graphic.yml
@@ -7,20 +7,11 @@ on:
     paths:
       - 'fastlane/**/title.txt'
       - '.scripts/generate_feature_graphic/**'
+
 permissions:
-  actions: none
-  checks: none
   contents: write
-  deployments: none
-  discussions: none
-  id-token: none
-  issues: none
-  packages: none
-  pages: none
   pull-requests: write
-  repository-projects: none
-  security-events: none
-  statuses: none
+
 jobs:
   generate-feature-graphic:
     runs-on: ubuntu-latest

--- a/.github/workflows/update-locales.yml
+++ b/.github/workflows/update-locales.yml
@@ -1,4 +1,5 @@
 name: Update locales
+
 on:
   workflow_dispatch:
   push:
@@ -7,20 +8,11 @@ on:
     paths:
       - app/src/main/res/values-*/strings.xml
       - app/src/main/res/values/settings.xml
+
 permissions:
-  actions: none
-  checks: none
   contents: write
-  deployments: none
-  discussions: none
-  id-token: none
-  issues: none
-  packages: none
-  pages: none
   pull-requests: write
-  repository-projects: none
-  security-events: none
-  statuses: none
+
 jobs:
   update-locales:
     runs-on: ubuntu-latest


### PR DESCRIPTION
If we specify even one permissions all others default to none/restricted so we can reduce the extra lines under permissions cause they are not needed anymore. 

So all of this :- 
https://github.com/CatimaLoyalty/Android/blob/5f33679ddda1fe28ffcf583c5a3a9e3074be04f9/.github/workflows/changelog-to-fastlane.yml#L9-L22

could be just
```
premissions:
  contents: write
  pull-requests: write
```

**All other will default to none. By default**


## Refrence to Github docs
Refrence :- https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#permissions 

> For each of the available permissions, shown in the table below, you can assign one of the access levels: read (if applicable), write, or none. write includes read. **If you specify the access for any of these permissions, all of those that are not specified are set to.** none.